### PR TITLE
Set Clubhouse API to Version 3

### DIFF
--- a/clubhouse/__init__.py
+++ b/clubhouse/__init__.py
@@ -8,7 +8,7 @@ from urllib.parse import urlparse
 import requests
 
 ENDPOINT_HOST = 'https://api.clubhouse.io'
-ENDPOINT_PATH = '/api/v2'
+ENDPOINT_PATH = '/api/v3'
 
 ClubhouseStory = Dict[str, object]
 ClubhouseUser = Dict[str, object]


### PR DESCRIPTION
Clubhouse has deprecated version 2 of their API. This changes the default to use version 3 of their API.

See https://clubhouse.io/api/rest/v2/#Introduction